### PR TITLE
Fix bug preventing use with rundotnetdll32

### DIFF
--- a/WheresMyImplant/Resources/Unmanaged/Libraries/advapi32.cs
+++ b/WheresMyImplant/Resources/Unmanaged/Libraries/advapi32.cs
@@ -173,7 +173,7 @@ namespace Unmanaged.Libraries
             ref int lpcbData
         );
 
-        
+        [DllImport("advapi32.dll", SetLastError = true)]
         public static extern Int32 RegQueryInfoKey(
             UIntPtr hKey,
             StringBuilder lpClass,


### PR DESCRIPTION
The method `RegQueryInfoKey` was missing an attribute specifying where it is implemented (DllImportAttribute).

Without this fix, rundotnetdll32 will fail with:
`Could not load type 'Unmanaged.Libraries.advapi32' from assembly 'WheresMyImplant, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5b985ef35ecad7a8' because the method 'RegQueryInfoKey' has no implementation (no RVA).`